### PR TITLE
Lyhennä og-otsikko

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,7 +15,7 @@
     <meta property="og:image:width" content="1800" />
     <meta property="og:image:height" content="2400" />   
     <meta property="og:locale" content="fi_FI">
-    <meta property="og:title" content="Mikael Rinnetmäki, terveysteknologiayrittäjä, potilasjärjestöaktiivi, kokoomuksen aluevaaliehdokas Pirkanmaalla">
+    <meta property="og:title" content="Mikael Rinnetmäki, terveysteknologiayrittäjä, potilasjärjestöaktiivi, aluevaaliehdokas Pirkanmaalla">
     <meta property="og:type" content="profile">
     <meta property="profile:first_name" content="Mikael">
     <meta property="profile:last_name" content="Rinnetmäki">


### PR DESCRIPTION
Pidemmästä jäi Pirkanmaa näkymättä Facebook-jaossa.